### PR TITLE
MER-2553: Major MDNavigationRail Changes

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1078,18 +1078,42 @@ class NavigationRailStory extends StatefulWidget {
 
 class _NavigationRailStoryState extends State<NavigationRailStory> {
   int _selectedIndex = 0;
-  bool _isExpanded = false;
+  late final MDNavigationRailController controller;
+  late final MDNavigationRailDestinationDecoration decoration;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = MDNavigationRailController(isHoverable: true);
+    decoration = MDNavigationRailDestinationDecoration(
+      context: context,
+      selectedColorOverride: Colors.deepPurple.shade100.withOpacity(.5),
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    controller.setExpandedButton(context.knobs.boolean(label: "Show Expand Button", initial: true));
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return MDLayout(
       sider: MDNavigationRail(
+          controller: controller,
           destinations: List.generate(
             context.knobs.sliderInt(label: "Items", initial: 4),
             (index) => MDNavigationRailDestination(
-              icon: const Icon(Icons.list),
+              icon: const Icon(Icons.list, color: Colors.black),
               label: 'Item $index',
-              selectedColor: Colors.deepPurple.shade100.withOpacity(.5),
+              decoration: decoration,
             ),
           ),
           selectedIndex: _selectedIndex,
@@ -1098,14 +1122,7 @@ class _NavigationRailStoryState extends State<NavigationRailStory> {
               _selectedIndex = index;
             });
           },
-          isExpanded: _isExpanded,
-          onExpandTap: context.knobs.boolean(label: "Show Expand Button", initial: true)
-              ? () {
-                  setState(() {
-                    _isExpanded = !_isExpanded;
-                  });
-                }
-              : null),
+          onExpandTap: () {}),
       content: const MDScaffold(body: Text("this is content")),
     );
   }
@@ -1132,6 +1149,15 @@ class LayoutView extends StatefulWidget {
 }
 
 class _LayoutViewState extends State<LayoutView> {
+  late final MDNavigationRailDestinationDecoration decoration;
+
+  @override
+  void initState() {
+    super.initState();
+    decoration = MDNavigationRailDestinationDecoration(
+        context: context, selectedColorOverride: Colors.deepPurple.shade100.withOpacity(.5));
+  }
+
   int _currentIndex = 0;
   bool _isExpanded = true;
 
@@ -1155,7 +1181,7 @@ class _LayoutViewState extends State<LayoutView> {
               (item) => MDNavigationRailDestination(
                 icon: item['icon'],
                 label: item['label'],
-                selectedColor: Colors.deepPurple.shade100.withOpacity(.5),
+                decoration: decoration,
               ),
             )
             .toList(),
@@ -1165,7 +1191,6 @@ class _LayoutViewState extends State<LayoutView> {
             _currentIndex = index;
           });
         },
-        isExpanded: _isExpanded,
         onExpandTap: () {
           setState(() {
             _isExpanded = !_isExpanded;

--- a/lib/flutter_meragi_design.dart
+++ b/lib/flutter_meragi_design.dart
@@ -53,3 +53,6 @@ export 'src/utils/platform.dart';
 export 'src/utils/scroll_handler.dart';
 export 'src/utils/shortcut_activators.dart';
 export 'src/utils/widget_state.dart';
+export 'src/components/layout/navigation_rail_controller.dart';
+export 'src/components/layout/navigation_rail_decoration.dart';
+export 'src/components/layout/navigation_rail_destination_decoration.dart';

--- a/lib/src/components/layout/navigation_rail.dart
+++ b/lib/src/components/layout/navigation_rail.dart
@@ -56,10 +56,7 @@ class MDNavigationRail extends StatelessWidget {
                     decoration: BoxDecoration(
                         color: finalDecoration.backgroundColor,
                         borderRadius: finalDecoration.borderRadius,
-                        boxShadow: const [
-                          BoxShadow(
-                              blurRadius: 12, spreadRadius: 3, color: Color(0xFFCFCFD2), blurStyle: BlurStyle.normal)
-                        ]),
+                        boxShadow: finalDecoration.boxShadow),
                     padding: finalDecoration.contentPadding,
                     child: builder != null
                         ? builder!.call(context, value.isExpanded)
@@ -278,12 +275,7 @@ class MDNavigationRailEmpty extends StatelessWidget {
       height: double.infinity,
       width: finalDecoration.collapsedWidth - 8,
       margin: const EdgeInsets.only(top: 8, right: 8, bottom: 8),
-      decoration: BoxDecoration(
-          color: finalDecoration.backgroundColor,
-          borderRadius: finalDecoration.borderRadius,
-          boxShadow: const [
-            BoxShadow(blurRadius: 12, spreadRadius: 3, color: Color(0xFFCFCFD2), blurStyle: BlurStyle.normal)
-          ]),
+      decoration: BoxDecoration(color: finalDecoration.backgroundColor, borderRadius: finalDecoration.borderRadius),
     );
   }
 }

--- a/lib/src/components/layout/navigation_rail_controller.dart
+++ b/lib/src/components/layout/navigation_rail_controller.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/foundation.dart';
+
+class MDNavigationRailController extends ChangeNotifier implements ValueListenable<bool> {
+  bool _isExpanded;
+  bool _isHoverable;
+  bool _expandedButton;
+
+  MDNavigationRailController({
+    final bool isExpanded = false,
+    final bool isHoverable = false,
+    final bool expandedButton = true,
+  })  : _isHoverable = isHoverable,
+        _isExpanded = isExpanded,
+        _expandedButton = expandedButton;
+
+  bool get isHoverable => _isHoverable;
+  bool get isExpanded => _isExpanded;
+  bool get expandedButton => _expandedButton;
+
+  void open({bool notifyListener = true}) {
+    _isExpanded = true;
+    if (notifyListener) notifyListeners();
+  }
+
+  void close({bool notifyListener = true}) {
+    _isExpanded = false;
+    if (notifyListener) notifyListeners();
+  }
+
+  void setHoverable(bool newValue, {bool notifyListener = true}) {
+    if (_isHoverable == newValue) return;
+
+    _isHoverable = newValue;
+    if (notifyListener) notifyListeners();
+  }
+
+  void setExpandedButton(bool newValue, {bool notifyListener = true}) {
+    if (_expandedButton == newValue) return;
+
+    _expandedButton = newValue;
+    if (notifyListener) notifyListeners();
+  }
+
+  @override
+  bool get value => _isExpanded;
+}

--- a/lib/src/components/layout/navigation_rail_decoration.dart
+++ b/lib/src/components/layout/navigation_rail_decoration.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_meragi_design/src/theme/style.dart';
+
+class MDNavigationRailDecoration extends Style {
+  MDNavigationRailDecoration({
+    required super.context,
+    final EdgeInsets? contentPaddingOverride,
+    final Color? backgroundColorOverride,
+    final BorderRadius? borderRadiusOverride,
+    final double? collapseWidthOverride,
+    final double? expandedWidthOverride,
+    final Duration? animationDurationOverride,
+  })  : _contentPaddingOverride = contentPaddingOverride,
+        _backgroundColorOverride = backgroundColorOverride,
+        _borderRadiusOverride = borderRadiusOverride,
+        _collapseWidthOverride = collapseWidthOverride,
+        _expandedWidthOverride = expandedWidthOverride,
+        _animationDurationOverride = animationDurationOverride;
+
+  final EdgeInsets? _contentPaddingOverride;
+  final Color? _backgroundColorOverride;
+  final BorderRadius? _borderRadiusOverride;
+  final double? _collapseWidthOverride;
+  final double? _expandedWidthOverride;
+  final Duration? _animationDurationOverride;
+
+  EdgeInsets get contentPadding => _contentPaddingOverride ?? token.navigationRailcontentPadding;
+
+  Color get backgroundColor => _backgroundColorOverride ?? token.navigationRailBackgroundColor;
+
+  double get collapsedWidth => _collapseWidthOverride ?? token.navigationRailCollapsedWidth;
+
+  double get expandedWidth => _expandedWidthOverride ?? token.navigationRailExpandedWidth;
+
+  BorderRadius get borderRadius => _borderRadiusOverride ?? token.navigationRailBorderRadius;
+
+  Duration get animationDuration => _animationDurationOverride ?? token.navigationRailAnimationDuration;
+
+  MDNavigationRailDecoration copyWith({
+    final EdgeInsets? contentPaddingOverride,
+    final Color? backgroundColorOverride,
+    final BorderRadius? borderRadiusOverride,
+    final double? collapseWidthOverride,
+    final double? expandedWidthOverride,
+    final Duration? animationDurationOverride,
+  }) {
+    return MDNavigationRailDecoration(
+      context: context,
+      contentPaddingOverride: contentPaddingOverride ?? contentPadding,
+      backgroundColorOverride: backgroundColorOverride ?? backgroundColor,
+      borderRadiusOverride: borderRadiusOverride ?? borderRadius,
+      collapseWidthOverride: collapseWidthOverride ?? collapsedWidth,
+      expandedWidthOverride: expandedWidthOverride ?? expandedWidth,
+      animationDurationOverride: animationDurationOverride ?? animationDuration,
+    );
+  }
+
+  MDNavigationRailDecoration merge(MDNavigationRailDecoration? other) {
+    if (other == null) {
+      return this;
+    }
+    return copyWith(
+      contentPaddingOverride: other.contentPadding,
+      backgroundColorOverride: other.backgroundColor,
+      borderRadiusOverride: other.borderRadius,
+      collapseWidthOverride: other.collapsedWidth,
+      expandedWidthOverride: other.expandedWidth,
+      animationDurationOverride: other.animationDuration,
+    );
+  }
+}

--- a/lib/src/components/layout/navigation_rail_decoration.dart
+++ b/lib/src/components/layout/navigation_rail_decoration.dart
@@ -10,11 +10,13 @@ class MDNavigationRailDecoration extends Style {
     final double? collapseWidthOverride,
     final double? expandedWidthOverride,
     final Duration? animationDurationOverride,
+    final List<BoxShadow>? boxShadowOverride,
   })  : _contentPaddingOverride = contentPaddingOverride,
         _backgroundColorOverride = backgroundColorOverride,
         _borderRadiusOverride = borderRadiusOverride,
         _collapseWidthOverride = collapseWidthOverride,
         _expandedWidthOverride = expandedWidthOverride,
+        _boxShadowOverride = boxShadowOverride,
         _animationDurationOverride = animationDurationOverride;
 
   final EdgeInsets? _contentPaddingOverride;
@@ -23,6 +25,7 @@ class MDNavigationRailDecoration extends Style {
   final double? _collapseWidthOverride;
   final double? _expandedWidthOverride;
   final Duration? _animationDurationOverride;
+  final List<BoxShadow>? _boxShadowOverride;
 
   EdgeInsets get contentPadding => _contentPaddingOverride ?? token.navigationRailcontentPadding;
 
@@ -36,6 +39,8 @@ class MDNavigationRailDecoration extends Style {
 
   Duration get animationDuration => _animationDurationOverride ?? token.navigationRailAnimationDuration;
 
+  List<BoxShadow> get boxShadow => _boxShadowOverride ?? token.navigationRailBoxShadow;
+
   MDNavigationRailDecoration copyWith({
     final EdgeInsets? contentPaddingOverride,
     final Color? backgroundColorOverride,
@@ -43,6 +48,7 @@ class MDNavigationRailDecoration extends Style {
     final double? collapseWidthOverride,
     final double? expandedWidthOverride,
     final Duration? animationDurationOverride,
+    final List<BoxShadow>? boxShadowOverride,
   }) {
     return MDNavigationRailDecoration(
       context: context,
@@ -52,6 +58,7 @@ class MDNavigationRailDecoration extends Style {
       collapseWidthOverride: collapseWidthOverride ?? collapsedWidth,
       expandedWidthOverride: expandedWidthOverride ?? expandedWidth,
       animationDurationOverride: animationDurationOverride ?? animationDuration,
+      boxShadowOverride: boxShadowOverride ?? boxShadow,
     );
   }
 
@@ -66,6 +73,7 @@ class MDNavigationRailDecoration extends Style {
       collapseWidthOverride: other.collapsedWidth,
       expandedWidthOverride: other.expandedWidth,
       animationDurationOverride: other.animationDuration,
+      boxShadowOverride: other.boxShadow,
     );
   }
 }

--- a/lib/src/components/layout/navigation_rail_destination_decoration.dart
+++ b/lib/src/components/layout/navigation_rail_destination_decoration.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_meragi_design/src/theme/style.dart';
+
+class MDNavigationRailDestinationDecoration extends Style {
+  MDNavigationRailDestinationDecoration({
+    required super.context,
+    final Color? selectedColorOverride,
+    final Color? selectedHoverColorOverride,
+    final Color? nonSelectedColorOverride,
+    final Color? nonSelectedHoverColorOverride,
+  })  : _selectedColorOverride = selectedColorOverride,
+        _selectedHoverColorOverride = selectedHoverColorOverride,
+        _nonSelectedColorOverride = nonSelectedColorOverride,
+        _nonSelectedHoverColorOverride = nonSelectedHoverColorOverride;
+
+  final Color? _selectedColorOverride;
+  final Color? _selectedHoverColorOverride;
+  final Color? _nonSelectedColorOverride;
+  final Color? _nonSelectedHoverColorOverride;
+
+  Color get selectedColor => _selectedColorOverride ?? token.navigationRailDestinationSelectedColor;
+  Color get selectedHoverColor => _selectedHoverColorOverride ?? token.navigationRailDestinationSelectedHoverColor;
+  Color get nonSelectedColor => _nonSelectedColorOverride ?? token.navigationRailDestinationNonSelectedColor;
+  Color get nonSelectedHoverColor =>
+      _nonSelectedHoverColorOverride ?? token.navigationRailDestinationNonSelectedHoverColor;
+
+  MDNavigationRailDestinationDecoration copyWith({
+    final Color? selectedColorOverride,
+    final Color? selectedHoverColorOverride,
+    final Color? nonSelectedColorOverride,
+    final Color? nonSelectedHoverColorOverride,
+  }) {
+    return MDNavigationRailDestinationDecoration(
+      context: context,
+      selectedColorOverride: selectedColorOverride ?? selectedColor,
+      selectedHoverColorOverride: selectedHoverColorOverride ?? selectedHoverColor,
+      nonSelectedColorOverride: nonSelectedColorOverride ?? nonSelectedColor,
+      nonSelectedHoverColorOverride: nonSelectedHoverColorOverride ?? nonSelectedHoverColor,
+    );
+  }
+
+  MDNavigationRailDestinationDecoration merge(MDNavigationRailDestinationDecoration? other) {
+    if (other == null) {
+      return this;
+    }
+    return copyWith(
+      selectedColorOverride: other.selectedColor,
+      selectedHoverColorOverride: other.selectedHoverColor,
+      nonSelectedColorOverride: other.nonSelectedColor,
+      nonSelectedHoverColorOverride: other.nonSelectedHoverColor,
+    );
+  }
+}

--- a/lib/src/theme/theme_tokens.dart
+++ b/lib/src/theme/theme_tokens.dart
@@ -330,6 +330,8 @@ class ThemeToken extends ThemeExtension<ThemeToken>
   final BorderRadius navigationRailBorderRadius;
   @override
   final Duration navigationRailAnimationDuration;
+  @override
+  final List<BoxShadow> navigationRailBoxShadow;
 
   const ThemeToken({
     // Button
@@ -474,6 +476,7 @@ class ThemeToken extends ThemeExtension<ThemeToken>
     required this.navigationRailDestinationNonSelectedHoverColor,
     required this.navigationRailBorderRadius,
     required this.navigationRailAnimationDuration,
+    required this.navigationRailBoxShadow,
   });
 
   ThemeToken copyWithColors({

--- a/lib/src/theme/theme_tokens.dart
+++ b/lib/src/theme/theme_tokens.dart
@@ -310,6 +310,26 @@ class ThemeToken extends ThemeExtension<ThemeToken>
   final Color errorTextColor;
   @override
   final Color defaultTextColor;
+  @override
+  final Color navigationRailBackgroundColor;
+  @override
+  final EdgeInsets navigationRailcontentPadding;
+  @override
+  final double navigationRailCollapsedWidth;
+  @override
+  final double navigationRailExpandedWidth;
+  @override
+  final Color navigationRailDestinationSelectedColor;
+  @override
+  final Color navigationRailDestinationSelectedHoverColor;
+  @override
+  final Color navigationRailDestinationNonSelectedHoverColor;
+  @override
+  final Color navigationRailDestinationNonSelectedColor;
+  @override
+  final BorderRadius navigationRailBorderRadius;
+  @override
+  final Duration navigationRailAnimationDuration;
 
   const ThemeToken({
     // Button
@@ -442,6 +462,18 @@ class ThemeToken extends ThemeExtension<ThemeToken>
     required this.codeTextStyle,
     required this.linkTextStyle,
     required this.captionTextStyle,
+
+    //navigationRail
+    required this.navigationRailBackgroundColor,
+    required this.navigationRailCollapsedWidth,
+    required this.navigationRailExpandedWidth,
+    required this.navigationRailcontentPadding,
+    required this.navigationRailDestinationSelectedColor,
+    required this.navigationRailDestinationSelectedHoverColor,
+    required this.navigationRailDestinationNonSelectedColor,
+    required this.navigationRailDestinationNonSelectedHoverColor,
+    required this.navigationRailBorderRadius,
+    required this.navigationRailAnimationDuration,
   });
 
   ThemeToken copyWithColors({

--- a/lib/src/theme/theme_tokens.tailor.dart
+++ b/lib/src/theme/theme_tokens.tailor.dart
@@ -136,6 +136,16 @@ mixin _$ThemeTokenTailorMixin on ThemeExtension<ThemeToken> {
   Color get infoTextColor;
   Color get errorTextColor;
   Color get defaultTextColor;
+  Color get navigationRailBackgroundColor;
+  EdgeInsets get navigationRailcontentPadding;
+  double get navigationRailCollapsedWidth;
+  double get navigationRailExpandedWidth;
+  Color get navigationRailDestinationSelectedColor;
+  Color get navigationRailDestinationSelectedHoverColor;
+  Color get navigationRailDestinationNonSelectedHoverColor;
+  Color get navigationRailDestinationNonSelectedColor;
+  BorderRadius get navigationRailBorderRadius;
+  Duration get navigationRailAnimationDuration;
 
   @override
   ThemeToken copyWith({
@@ -266,6 +276,16 @@ mixin _$ThemeTokenTailorMixin on ThemeExtension<ThemeToken> {
     Color? infoTextColor,
     Color? errorTextColor,
     Color? defaultTextColor,
+    Color? navigationRailBackgroundColor,
+    EdgeInsets? navigationRailcontentPadding,
+    double? navigationRailCollapsedWidth,
+    double? navigationRailExpandedWidth,
+    Color? navigationRailDestinationSelectedColor,
+    Color? navigationRailDestinationSelectedHoverColor,
+    Color? navigationRailDestinationNonSelectedHoverColor,
+    Color? navigationRailDestinationNonSelectedColor,
+    BorderRadius? navigationRailBorderRadius,
+    Duration? navigationRailAnimationDuration,
   }) {
     return ThemeToken(
       defaultCardBackgroundColor:
@@ -436,6 +456,30 @@ mixin _$ThemeTokenTailorMixin on ThemeExtension<ThemeToken> {
       infoTextColor: infoTextColor ?? this.infoTextColor,
       errorTextColor: errorTextColor ?? this.errorTextColor,
       defaultTextColor: defaultTextColor ?? this.defaultTextColor,
+      navigationRailBackgroundColor:
+          navigationRailBackgroundColor ?? this.navigationRailBackgroundColor,
+      navigationRailcontentPadding:
+          navigationRailcontentPadding ?? this.navigationRailcontentPadding,
+      navigationRailCollapsedWidth:
+          navigationRailCollapsedWidth ?? this.navigationRailCollapsedWidth,
+      navigationRailExpandedWidth:
+          navigationRailExpandedWidth ?? this.navigationRailExpandedWidth,
+      navigationRailDestinationSelectedColor:
+          navigationRailDestinationSelectedColor ??
+              this.navigationRailDestinationSelectedColor,
+      navigationRailDestinationSelectedHoverColor:
+          navigationRailDestinationSelectedHoverColor ??
+              this.navigationRailDestinationSelectedHoverColor,
+      navigationRailDestinationNonSelectedHoverColor:
+          navigationRailDestinationNonSelectedHoverColor ??
+              this.navigationRailDestinationNonSelectedHoverColor,
+      navigationRailDestinationNonSelectedColor:
+          navigationRailDestinationNonSelectedColor ??
+              this.navigationRailDestinationNonSelectedColor,
+      navigationRailBorderRadius:
+          navigationRailBorderRadius ?? this.navigationRailBorderRadius,
+      navigationRailAnimationDuration: navigationRailAnimationDuration ??
+          this.navigationRailAnimationDuration,
     );
   }
 
@@ -647,6 +691,39 @@ mixin _$ThemeTokenTailorMixin on ThemeExtension<ThemeToken> {
       errorTextColor: Color.lerp(errorTextColor, other.errorTextColor, t)!,
       defaultTextColor:
           Color.lerp(defaultTextColor, other.defaultTextColor, t)!,
+      navigationRailBackgroundColor: Color.lerp(navigationRailBackgroundColor,
+          other.navigationRailBackgroundColor, t)!,
+      navigationRailcontentPadding: t < 0.5
+          ? navigationRailcontentPadding
+          : other.navigationRailcontentPadding,
+      navigationRailCollapsedWidth: t < 0.5
+          ? navigationRailCollapsedWidth
+          : other.navigationRailCollapsedWidth,
+      navigationRailExpandedWidth: t < 0.5
+          ? navigationRailExpandedWidth
+          : other.navigationRailExpandedWidth,
+      navigationRailDestinationSelectedColor: Color.lerp(
+          navigationRailDestinationSelectedColor,
+          other.navigationRailDestinationSelectedColor,
+          t)!,
+      navigationRailDestinationSelectedHoverColor: Color.lerp(
+          navigationRailDestinationSelectedHoverColor,
+          other.navigationRailDestinationSelectedHoverColor,
+          t)!,
+      navigationRailDestinationNonSelectedHoverColor: Color.lerp(
+          navigationRailDestinationNonSelectedHoverColor,
+          other.navigationRailDestinationNonSelectedHoverColor,
+          t)!,
+      navigationRailDestinationNonSelectedColor: Color.lerp(
+          navigationRailDestinationNonSelectedColor,
+          other.navigationRailDestinationNonSelectedColor,
+          t)!,
+      navigationRailBorderRadius: t < 0.5
+          ? navigationRailBorderRadius
+          : other.navigationRailBorderRadius,
+      navigationRailAnimationDuration: t < 0.5
+          ? navigationRailAnimationDuration
+          : other.navigationRailAnimationDuration,
     );
   }
 
@@ -820,7 +897,17 @@ mixin _$ThemeTokenTailorMixin on ThemeExtension<ThemeToken> {
             const DeepCollectionEquality().equals(warningTextColor, other.warningTextColor) &&
             const DeepCollectionEquality().equals(infoTextColor, other.infoTextColor) &&
             const DeepCollectionEquality().equals(errorTextColor, other.errorTextColor) &&
-            const DeepCollectionEquality().equals(defaultTextColor, other.defaultTextColor));
+            const DeepCollectionEquality().equals(defaultTextColor, other.defaultTextColor) &&
+            const DeepCollectionEquality().equals(navigationRailBackgroundColor, other.navigationRailBackgroundColor) &&
+            const DeepCollectionEquality().equals(navigationRailcontentPadding, other.navigationRailcontentPadding) &&
+            const DeepCollectionEquality().equals(navigationRailCollapsedWidth, other.navigationRailCollapsedWidth) &&
+            const DeepCollectionEquality().equals(navigationRailExpandedWidth, other.navigationRailExpandedWidth) &&
+            const DeepCollectionEquality().equals(navigationRailDestinationSelectedColor, other.navigationRailDestinationSelectedColor) &&
+            const DeepCollectionEquality().equals(navigationRailDestinationSelectedHoverColor, other.navigationRailDestinationSelectedHoverColor) &&
+            const DeepCollectionEquality().equals(navigationRailDestinationNonSelectedHoverColor, other.navigationRailDestinationNonSelectedHoverColor) &&
+            const DeepCollectionEquality().equals(navigationRailDestinationNonSelectedColor, other.navigationRailDestinationNonSelectedColor) &&
+            const DeepCollectionEquality().equals(navigationRailBorderRadius, other.navigationRailBorderRadius) &&
+            const DeepCollectionEquality().equals(navigationRailAnimationDuration, other.navigationRailAnimationDuration));
   }
 
   @override
@@ -954,6 +1041,20 @@ mixin _$ThemeTokenTailorMixin on ThemeExtension<ThemeToken> {
       const DeepCollectionEquality().hash(infoTextColor),
       const DeepCollectionEquality().hash(errorTextColor),
       const DeepCollectionEquality().hash(defaultTextColor),
+      const DeepCollectionEquality().hash(navigationRailBackgroundColor),
+      const DeepCollectionEquality().hash(navigationRailcontentPadding),
+      const DeepCollectionEquality().hash(navigationRailCollapsedWidth),
+      const DeepCollectionEquality().hash(navigationRailExpandedWidth),
+      const DeepCollectionEquality()
+          .hash(navigationRailDestinationSelectedColor),
+      const DeepCollectionEquality()
+          .hash(navigationRailDestinationSelectedHoverColor),
+      const DeepCollectionEquality()
+          .hash(navigationRailDestinationNonSelectedHoverColor),
+      const DeepCollectionEquality()
+          .hash(navigationRailDestinationNonSelectedColor),
+      const DeepCollectionEquality().hash(navigationRailBorderRadius),
+      const DeepCollectionEquality().hash(navigationRailAnimationDuration),
     ]);
   }
 }
@@ -1094,4 +1195,24 @@ extension ThemeTokenBuildContextProps on BuildContext {
   Color get infoTextColor => themeToken.infoTextColor;
   Color get errorTextColor => themeToken.errorTextColor;
   Color get defaultTextColor => themeToken.defaultTextColor;
+  Color get navigationRailBackgroundColor =>
+      themeToken.navigationRailBackgroundColor;
+  EdgeInsets get navigationRailcontentPadding =>
+      themeToken.navigationRailcontentPadding;
+  double get navigationRailCollapsedWidth =>
+      themeToken.navigationRailCollapsedWidth;
+  double get navigationRailExpandedWidth =>
+      themeToken.navigationRailExpandedWidth;
+  Color get navigationRailDestinationSelectedColor =>
+      themeToken.navigationRailDestinationSelectedColor;
+  Color get navigationRailDestinationSelectedHoverColor =>
+      themeToken.navigationRailDestinationSelectedHoverColor;
+  Color get navigationRailDestinationNonSelectedHoverColor =>
+      themeToken.navigationRailDestinationNonSelectedHoverColor;
+  Color get navigationRailDestinationNonSelectedColor =>
+      themeToken.navigationRailDestinationNonSelectedColor;
+  BorderRadius get navigationRailBorderRadius =>
+      themeToken.navigationRailBorderRadius;
+  Duration get navigationRailAnimationDuration =>
+      themeToken.navigationRailAnimationDuration;
 }

--- a/lib/src/theme/theme_tokens.tailor.dart
+++ b/lib/src/theme/theme_tokens.tailor.dart
@@ -146,6 +146,7 @@ mixin _$ThemeTokenTailorMixin on ThemeExtension<ThemeToken> {
   Color get navigationRailDestinationNonSelectedColor;
   BorderRadius get navigationRailBorderRadius;
   Duration get navigationRailAnimationDuration;
+  List<BoxShadow> get navigationRailBoxShadow;
 
   @override
   ThemeToken copyWith({
@@ -286,6 +287,7 @@ mixin _$ThemeTokenTailorMixin on ThemeExtension<ThemeToken> {
     Color? navigationRailDestinationNonSelectedColor,
     BorderRadius? navigationRailBorderRadius,
     Duration? navigationRailAnimationDuration,
+    List<BoxShadow>? navigationRailBoxShadow,
   }) {
     return ThemeToken(
       defaultCardBackgroundColor:
@@ -480,6 +482,8 @@ mixin _$ThemeTokenTailorMixin on ThemeExtension<ThemeToken> {
           navigationRailBorderRadius ?? this.navigationRailBorderRadius,
       navigationRailAnimationDuration: navigationRailAnimationDuration ??
           this.navigationRailAnimationDuration,
+      navigationRailBoxShadow:
+          navigationRailBoxShadow ?? this.navigationRailBoxShadow,
     );
   }
 
@@ -724,6 +728,8 @@ mixin _$ThemeTokenTailorMixin on ThemeExtension<ThemeToken> {
       navigationRailAnimationDuration: t < 0.5
           ? navigationRailAnimationDuration
           : other.navigationRailAnimationDuration,
+      navigationRailBoxShadow:
+          t < 0.5 ? navigationRailBoxShadow : other.navigationRailBoxShadow,
     );
   }
 
@@ -907,7 +913,8 @@ mixin _$ThemeTokenTailorMixin on ThemeExtension<ThemeToken> {
             const DeepCollectionEquality().equals(navigationRailDestinationNonSelectedHoverColor, other.navigationRailDestinationNonSelectedHoverColor) &&
             const DeepCollectionEquality().equals(navigationRailDestinationNonSelectedColor, other.navigationRailDestinationNonSelectedColor) &&
             const DeepCollectionEquality().equals(navigationRailBorderRadius, other.navigationRailBorderRadius) &&
-            const DeepCollectionEquality().equals(navigationRailAnimationDuration, other.navigationRailAnimationDuration));
+            const DeepCollectionEquality().equals(navigationRailAnimationDuration, other.navigationRailAnimationDuration) &&
+            const DeepCollectionEquality().equals(navigationRailBoxShadow, other.navigationRailBoxShadow));
   }
 
   @override
@@ -1055,6 +1062,7 @@ mixin _$ThemeTokenTailorMixin on ThemeExtension<ThemeToken> {
           .hash(navigationRailDestinationNonSelectedColor),
       const DeepCollectionEquality().hash(navigationRailBorderRadius),
       const DeepCollectionEquality().hash(navigationRailAnimationDuration),
+      const DeepCollectionEquality().hash(navigationRailBoxShadow),
     ]);
   }
 }
@@ -1215,4 +1223,6 @@ extension ThemeTokenBuildContextProps on BuildContext {
       themeToken.navigationRailBorderRadius;
   Duration get navigationRailAnimationDuration =>
       themeToken.navigationRailAnimationDuration;
+  List<BoxShadow> get navigationRailBoxShadow =>
+      themeToken.navigationRailBoxShadow;
 }

--- a/lib/src/theme/tokens/light.dart
+++ b/lib/src/theme/tokens/light.dart
@@ -136,4 +136,16 @@ ThemeToken light = ThemeToken(
   infoTagBackgroundColor: Colors.blue.withOpacity(.3),
   infoTagBorderColor: Colors.blue.shade100.withOpacity(.3),
   infoTagTextColor: Colors.blue,
+
+  //navigationRail
+  navigationRailBackgroundColor: Colors.white,
+  navigationRailCollapsedWidth: 65,
+  navigationRailExpandedWidth: 250,
+  navigationRailcontentPadding: const EdgeInsets.all(15),
+  navigationRailDestinationSelectedColor: Colors.deepPurpleAccent.shade100.withOpacity(.3),
+  navigationRailDestinationNonSelectedHoverColor: Colors.deepPurple[100]!.withOpacity(0.7),
+  navigationRailDestinationNonSelectedColor: Colors.deepPurple.shade100.withOpacity(0.2),
+  navigationRailDestinationSelectedHoverColor: Colors.deepPurple[200]!.withOpacity(0.7),
+  navigationRailBorderRadius: const BorderRadius.all(Radius.circular(12)),
+  navigationRailAnimationDuration: const Duration(milliseconds: 150),
 );

--- a/lib/src/theme/tokens/light.dart
+++ b/lib/src/theme/tokens/light.dart
@@ -148,4 +148,7 @@ ThemeToken light = ThemeToken(
   navigationRailDestinationSelectedHoverColor: Colors.deepPurple[200]!.withOpacity(0.7),
   navigationRailBorderRadius: const BorderRadius.all(Radius.circular(12)),
   navigationRailAnimationDuration: const Duration(milliseconds: 150),
+  navigationRailBoxShadow: const [
+    BoxShadow(blurRadius: 12, spreadRadius: 3, color: Color(0xFFCFCFD2), blurStyle: BlurStyle.normal)
+  ],
 );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_meragi_design
 description: Meragi Design System For Flutter
-version: 3.1.3
+version: 3.2.0
 homepage: "meragi.com"
 
 environment:
@@ -26,6 +26,7 @@ dependencies:
   vsc_quill_delta_to_html: ^1.0.5
   flutter_scatter: ^0.2.0
   sprintf: ^7.0.0
+  provider: ^6.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
* Added a Navigation Rail Controller with the following properties
    1) Added a property where the navigation rail expands and collapses when the mouse cursor hovers over the navigation rail. To activate the property, you will need to set a `MDNavigationRailController` with the property `isHoverable` as true.
    3) To programmatically open or close the navigation rail, you can use the `MDNavigationRailController.open()` and `MDNavigationRailController.close()` (Please note that they are not static methods)
    4) in all the setter methods like `setHoverable` has a parameter called notifylisteners. By default they are true. This parameter can be used in the case where you want to change a property but to notify the listeners later (But it does not manually trigger the notifiers at the later time, that needs to be done programmatically).
    5) Controller implements a `ValueListenable<bool>` and extends a ChangeNotifier (which by defaults extends listenable). This controller can be used inside a bloc and inside any listenable widgets. The value that it listens to by default is the `isExpanded`.  But calling any setter methods will trigger all the listeners of the controller even though, by default, it listens to `isExpanded`
    6) If you don't pass any controllers inside the widget, it will make a controller for you with default values set in it.
    7) To make the NavigationRail work on top of the other widgets, you will need to things. 
        1) Put a MDNavigationRailEmpty() widget. This is a dummy widget which will take an actual spot in the widget tree.
        2) After that you will need to wrap the entire widget with a stack and then put the MDNavigationRail() widget below the stack
         ```
          Stack:
              children: 
                  Row:
                      children: 
                          MDNavigationRailEmpty()
                          (Your other Widgets)
                  MDNavigationRail()
          ```
* Added `MDNavigationRailDecoration` to provide decoration to both the `MDNavigationRail` and the `MDNavigationRailEmpty` (Note, to make sure that both the dummy and the actual widget are having the same decorations)
* Added `MDNavigationRailDestinationDecoration` for providing the destination decoration
* In the widget, there are 2 ways to fill up the navigation rail.
    1) There is a builder parameter with an context and `isExpanded`. You can use the isExpanded property to check if the rail is collasped or expanded, however changing the value of the isExpanded property will not programmatically close or open the rail. To achieve that, you will need to pass in the controller and trigger any changes through the controller.
    2) There is `destinations`, where you pass in a list of `MDNavigationRailDestination` and it will make the list for you.
    Note: You will have to either pass in the `builder` OR (`destinations` AND `onDestinationSelected`)